### PR TITLE
Fix/handle vars as args

### DIFF
--- a/stpv
+++ b/stpv
@@ -83,14 +83,14 @@ img_to_txt() {
 }
 
 colorize_src() {
-    [ "$1" = --md ] && {
-        batmd='--language markdown'
+    if [ "$1" = "--md" ]; then
+        bat --color always --style plain --language markdown -- "$@" && return 0
         higmd='markdown'
         shift
-    }
+    fi
     highlight --replace-tabs=4 --out-format=ansi \
               --style='pablo' --force -- "$higmd" "$@" 2>/dev/null && return 0
-    bat --color always --style plain "$batmd" -- "$@" && return 0
+    bat --color always --style plain -- "$@" && return 0
 }
 
 view_pandoc() {

--- a/stpv
+++ b/stpv
@@ -89,8 +89,8 @@ colorize_src() {
         shift
     }
     highlight --replace-tabs=4 --out-format=ansi \
-              --style='pablo' --force -- $higmd "$@" && return 0
-    bat --color always --style plain $batmd -- "$@" && return 0
+              --style='pablo' --force -- "$higmd" "$@" 2>/dev/null && return 0
+    bat --color always --style plain "$batmd" -- "$@" && return 0
 }
 
 view_pandoc() {
@@ -181,7 +181,7 @@ handle_mime() {
             # Preview as text conversion
             # viu "${FILE_PATH}"
             # img2txt --gamma=0.6 -- "${FILE_PATH}"
-            [ $(du "${FILE_PATH}" | cut -f 1) -le 6000 ] && { # only if <= 6M
+            [ "$(du "${FILE_PATH}" | cut -f 1)" -le 6000 ] && { # only if <= 6M
                 img_to_txt "${FILE_PATH}" || { # probably if not jpg
                     j=/tmp/stpvjp2atmp.jpg
                     convert "${FILE_PATH}" "$j"


### PR DESCRIPTION
-   Quote variables to prevent globbing and word splitting (courtesy of ShellCheck)
-   Fix bat syntax highlighting caused by empty variable `$batmd`