### PR TITLE
Use vertical preview if window exceeds min width

### DIFF
--- a/fzfp
+++ b/fzfp
@@ -12,7 +12,7 @@ elif [[ "$W" -gt 52 || "$H" -gt 13 ]]; then
     COLS=$(tput cols)
     LINS=$(tput lines)
     PV=(--preview-window)
-    if [ "$W" -gt $((H*3)) ]; then
+    if [ "$W" -gt $((H*3)) ] || [ "$W" -gt 169 ]; then
         PV+=(right:50%)
         X=$((COLS / 2 + 2))
         Y=1


### PR DESCRIPTION
If the window width is 170 columns wide, then FZF's preview will be 80
columns wide when vertically split; this should be enough to preview
most files.