### PR TITLE
Output a subset of markdown supported by `mdcat`

### DIFF
--- a/stpv
+++ b/stpv
@@ -102,7 +102,7 @@ colorize_src() {
 }
 
 view_pandoc() {
-    text=$(pandoc "$1" -t markdown --columns="$W" -s)
+    text=$(pandoc "$1" -t markdown_github+yaml_metadata_block --columns="$W" -s)
     echo "$text" | mdcat && exit 0
     echo "$text" | colorize_src --md && exit 0
 }


### PR DESCRIPTION
`mdcat` doesn't support some of Pandoc's markdown features; use only a
slight superset of commonmark (specifically markdown_github along with
yaml metadata blocks, which seems to be covered by `mdcat` and `bat`).

This solves syntax highlighting issues with pandoc's fancy fenced code
blocks; outputting text in this format allows `mdcat` to do syntax
highlighting of code snippets properly.