### PR TITLE
Add support for diff/patch files

### DIFF
--- a/stpv
+++ b/stpv
@@ -183,13 +183,17 @@ handle_mime() {
             exit 1;;
 
         text/x-diff)
+            # use the user-specified git diff pager if it is set
             if git config core.pager >/dev/null; then
                 eval "$(git config core.pager)" < "${FILE_PATH}" && exit 0
             fi
+            # delta and diff-so-fancy are fancy diff pagers.
             delta "${FILE_PATH}" && exit 0
             diff-so-fancy "${FILE_PATH}" && exit 0
+            # colorize_src uses highlight or bat, both of which support
+            # diff/patch syntax.
             colorize_src "${FILE_PATH}" && exit 0
-						exit 1;;
+            exit 1;;
 
         # Text
         text/* | */xml | */json)

--- a/stpv
+++ b/stpv
@@ -182,6 +182,15 @@ handle_mime() {
             ls --color --group-directories-first "${FILE_PATH}" && exit 0
             exit 1;;
 
+        text/x-diff)
+            if git config core.pager >/dev/null; then
+                eval "$(git config core.pager)" < "${FILE_PATH}" && exit 0
+            fi
+            delta "${FILE_PATH}" && exit 0
+            diff-so-fancy "${FILE_PATH}" && exit 0
+            colorize_src "${FILE_PATH}" && exit 0
+						exit 1;;
+
         # Text
         text/* | */xml | */json)
             # Syntax highlight


### PR DESCRIPTION
[`delta`](https://github.com/dandavison/delta) and [`diff-so-fancy`](https://github.com/so-fancy/diff-so-fancy) have better highlighting of diff/patch files than highlight and bat; use those or the user-preferred diff pager if available.