### PR TITLE
use mimetype (Perl MimeInfo) program by default

### DIFF
--- a/stpv
+++ b/stpv
@@ -374,7 +374,10 @@ real_main() {
     IMAGE_CACHE_PATH="$IMAGE_CACHE_DIR/$IMAGE_CACHE_HASH.jpg"
     FILE_EXTENSION="${FILE_PATH##*.}"
     FILE_EXTENSION_LOWER=$(echo "$FILE_EXTENSION" | tr '[:upper:]' '[:lower:]')
-    MIMETYPE=$(file --dereference --brief --mime-type -- "${FILE_PATH}")
+    MIMETYPE=$(mimetype --dereference --brief --mimetype -- "${FILE_PATH}")
+    if [ "$?" -ne 0 ] || [ -z "$MIMETYPE" ]; then
+	    MIMETYPE=$(file --dereference --brief --mime-type -- "${FILE_PATH}")
+    fi
 
     [ "$PV_IMAGE_ENABLED" ] &&
         [ "$STPV_NO_IMG" = 1 ] ||


### PR DESCRIPTION
I found that the `mimetype` program from Perls File-MimeInfo module usally gives better results for mimetypes. So I suggest using it as a default and only use the standard `file` program as a fallback option. `mimetype` should also already be installed on many distributions.

The reason `file` gives less accurate output, is that it does not follow the XDG standard and so some registered mimetypes are not detected by it. (Sources: https://wiki.archlinux.org/title/Default_applications#perl-file-mimeinfo and https://wiki.archlinux.org/title/Xdg-utils#xdg-open)
On my system for example, it fails to correctly identify Xournall++ files. `file` detects them as an `application/gzip`, while `mimetype` correctly detects them as an `application/x-xopp`.

An alternative would be to use the `xdg-mime` (from `xdg-utils`) program, which uses `mimetype` as a default and `file` as a fallback. But it has a slightly more complex syntax and I don't really know how it behaves with desktop enviroments. (But I think it is unaffected by the current enviroment and only `xdg-open` takes the current DE into account.)