### PR TITLE
Implement support for Xournal++ files

### DIFF
--- a/stpv
+++ b/stpv
@@ -274,6 +274,20 @@ handle_image() {
                 --outdir "$CACHE_DIR" &&
                 mv "$TMP_FILE_PATH" "$IMAGE_CACHE_PATH";;
 
+        # Xounralpp files
+        application/x-xopp)
+            CACHE_DIR="${IMAGE_CACHE_PATH%/*}"
+            TMP_FILE_PATH="${FILE_PATH##*/}"
+            TMP_FILE_PATHBASE="${CACHE_DIR}/${TMP_FILE_PATH%.*}"
+            rm -f "${TMP_FILE_PATHBASE}.jpg"
+            rm -f "${TMP_FILE_PATHBASE}-"*".jpg"
+            xournalpp \
+                --create-img "${TMP_FILE_PATHBASE}.jpg" \
+                "${FILE_PATH}" &&
+		mv "${TMP_FILE_PATHBASE}.jpg" "$IMAGE_CACHE_PATH" ||
+		mv "${TMP_FILE_PATHBASE}-1.jpg" "$IMAGE_CACHE_PATH"
+            rm -f "${TMP_FILE_PATHBASE}-"*".jpg";;
+
         # Other types
         *) return 1;;
     esac && {

--- a/stpv
+++ b/stpv
@@ -374,7 +374,10 @@ real_main() {
     IMAGE_CACHE_PATH="$IMAGE_CACHE_DIR/$IMAGE_CACHE_HASH.jpg"
     FILE_EXTENSION="${FILE_PATH##*.}"
     FILE_EXTENSION_LOWER=$(echo "$FILE_EXTENSION" | tr '[:upper:]' '[:lower:]')
-    MIMETYPE=$(file --dereference --brief --mime-type -- "${FILE_PATH}")
+    MIMETYPE=$(mimetype --dereference --brief --mimetype -- "${FILE_PATH}")
+    if [ "$?" -ne 0 ] || [ -z "$MIMETYPE" ]; then
+	    MIMETYPE=$(file --dereference --brief --mime-type -- "${FILE_PATH}")
+    fi
 
     [ "$PV_IMAGE_ENABLED" ] &&
         [ "$STPV_NO_IMG" = 1 ] ||


### PR DESCRIPTION
I implemented support for the Xournal++ files. I implemented them in a simmilar way to the LibreOffice files.

This PR is based on #9. This is necessary because (how I pointed in #9 already out) `file` does not detect the mimetype correctly and currently the image handling is only based on mimetypes and not file extensions.