### PR TITLE
fix lf file manager image previewes

### DIFF
--- a/stpv
+++ b/stpv
@@ -135,11 +135,14 @@ real_main() {
         mimetype=$(mimetype --dereference --brief --mimetype -- "$file_path")
         show_fallback=
         handle_now
-        if [ $? = $RET_FALLBACK ]; then
+        handler_exit_code=$?
+        if [ $handler_exit_code = $RET_FALLBACK ]; then
             # if nothing is found using mimetype, try file
             mimetype=$(file --dereference --brief --mime-type -- "$file_path")
             show_fallback=1
             handle_now
+        else
+            return $handler_exit_code
         fi
     else
         mimetype=$(file --dereference --brief --mime-type -- "$file_path")


### PR DESCRIPTION
add an `else` statement to make sure the handler exit code is returned.

I am not that proficient in shell scripting but as far as I understand it, the problem is that when the code execution does not enter the `if` statement, the last executed line of code becomes the `test` statement, which does so successfully so the exit code of the previewer script becomes `0` regardless of what the handler function returns. Thus braking **lf** file manager image preview functionality.