### PR TITLE
Add source-hightlight support

### DIFF
--- a/README.org
+++ b/README.org
@@ -7,27 +7,27 @@
    - [[https://github.com/seebye/ueberzug][ueberzug]] or [[https://github.com/hpjansson/chafa/][chafa]] for image previews
    - The following programs. Note that the names are the command names and not the package names
 
-   | type        | cli program                      | image program     |
-   |-------------+----------------------------------+-------------------|
-   | directory   | ls                               | -                 |
-   | archive     | xzcat,zcat,atool,bsdtar          | -                 |
-   | rar         | unrar                            | -                 |
-   | 7z+iso      | 7z                               | -                 |
-   | html        | w3m,lynx,elinks,pandoc           | -                 |
-   | json        | jq,=text-source                  | -                 |
-   | markdown    | pandoc,=text-source              | -                 |
-   | csv         | pandoc,cat                       | -                 |
-   | diff        | delta,diff-so-fancy,=text-source | -                 |
-   | pdf         | pdftotext,mutool,exiftool        | pdftoppm          |
-   | epub        | epub2txt                         | -                 |
-   | text-source | mdcat,bat,highlight,cat          | -                 |
-   | image       | exiftool                         | convert           |
-   | video       | exiftool                         | ffmpegthumbnailer |
-   | audio       | exiftool                         | -                 |
-   | office      | pandoc,libreoffice               | libreoffice       |
-   | xounralpp   | -                                | xournalpp         |
-   | torrent     | transmission-show                | -                 |
-   | stl         | -                                | openscad+convert  |
+   | type        | cli program                              | image program     |
+   |-------------+------------------------------------------+-------------------|
+   | directory   | ls                                       | -                 |
+   | archive     | xzcat,zcat,atool,bsdtar                  | -                 |
+   | rar         | unrar                                    | -                 |
+   | 7z+iso      | 7z                                       | -                 |
+   | html        | w3m,lynx,elinks,pandoc                   | -                 |
+   | json        | jq,=text-source                          | -                 |
+   | markdown    | pandoc,=text-source                      | -                 |
+   | csv         | pandoc,cat                               | -                 |
+   | diff        | delta,diff-so-fancy,=text-source         | -                 |
+   | pdf         | pdftotext,mutool,exiftool                | pdftoppm          |
+   | epub        | epub2txt                                 | -                 |
+   | text-source | mdcat,bat,highlight,source-highlight,cat | -                 |
+   | image       | exiftool                                 | convert           |
+   | video       | exiftool                                 | ffmpegthumbnailer |
+   | audio       | exiftool                                 | -                 |
+   | office      | pandoc,libreoffice                       | libreoffice       |
+   | xounralpp   | -                                        | xournalpp         |
+   | torrent     | transmission-show                        | -                 |
+   | stl         | -                                        | openscad+convert  |
 
    Overall, it should work fine without most dependencies, it will fallback to simpler previews.
 

--- a/stpv
+++ b/stpv
@@ -330,6 +330,9 @@ colorize_src() {
         elif exists highlight; then
             highlight --replace-tabs=4 --out-format=ansi \
                       --style='pablo' --force -- "$@"
+        elif exists source-highlight; then
+            source-highlight --tab=4 --out-format=esc \
+                      --style=esc256.style --failsafe -i "$@"
         else
             cat "$1"
         fi
@@ -531,7 +534,7 @@ handle_epub() {
     epub2txt "$file_path"
 }
 
-add handle_text text-source mdcat,bat,highlight,cat -
+add handle_text text-source mdcat,bat,highlight,source-highlight,cat -
 handle_text() {
     case "$mimetype" in
         text/* | */xml                | \


### PR DESCRIPTION
`source-highlight` is a GNU program for syntax highlighting: https://www.gnu.org/software/src-highlite/source-highlight.html

This PR adds support for it.