### PR TITLE
Makefile improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-PREFIX = /usr
+PREFIX = /usr/local
+
 CWD = $(CURDIR)
 
 install:

--- a/Makefile
+++ b/Makefile
@@ -1,25 +1,26 @@
-PREFIX = /usr/local
+PREFIX    = /usr/local
+BINPREFIX = $(DESTDIR)$(PREFIX)/bin
 
 CWD = $(CURDIR)
 
 install:
-	mkdir -p $(DESTDIR)$(PREFIX)/bin/
-	cp -f stpv $(DESTDIR)$(PREFIX)/bin/
-	cp -f stpvimg $(DESTDIR)$(PREFIX)/bin/
-	cp -f stpvimgclr $(DESTDIR)$(PREFIX)/bin/
-	cp -f fzfp $(DESTDIR)$(PREFIX)/bin/
+	mkdir -p $(BINPREFIX)
+	cp -f stpv $(BINPREFIX)/
+	cp -f stpvimg $(BINPREFIX)/
+	cp -f stpvimgclr $(BINPREFIX)/
+	cp -f fzfp $(BINPREFIX)/
 
 link:
-	mkdir -p $(DESTDIR)$(PREFIX)/bin/
-	ln -sf $(CWD)/stpv $(DESTDIR)$(PREFIX)/bin/
-	ln -sf $(CWD)/stpvimg $(DESTDIR)$(PREFIX)/bin/
-	ln -sf $(CWD)/stpvimgclr $(DESTDIR)$(PREFIX)/bin/
-	ln -sf $(CWD)/fzfp $(DESTDIR)$(PREFIX)/bin/
+	mkdir -p $(BINPREFIX)
+	ln -sf $(CWD)/stpv $(BINPREFIX)/
+	ln -sf $(CWD)/stpvimg $(BINPREFIX)/
+	ln -sf $(CWD)/stpvimgclr $(BINPREFIX)/
+	ln -sf $(CWD)/fzfp $(BINPREFIX)/
 
 uninstall:
-	rm -f $(DESTDIR)$(PREFIX)/bin/stpv
-	rm -f $(DESTDIR)$(PREFIX)/bin/stpvimg
-	rm -f $(DESTDIR)$(PREFIX)/bin/stpvimgclr
-	rm -f $(DESTDIR)$(PREFIX)/bin/fzfp
+	rm -f $(BINPREFIX)/stpv
+	rm -f $(BINPREFIX)/stpvimg
+	rm -f $(BINPREFIX)/stpvimgclr
+	rm -f $(BINPREFIX)/fzfp
 
-.PHONY: install uninstall
+.PHONY: install link uninstall


### PR DESCRIPTION
This PR adds several minor improvements to the Makefile:

* Use `/usr/local` as the default install prefix. `/usr` is a prefix used by system package managers and should never be touched by installations done manually (without a package manager).
* Add `BINPREFIX` to avoid repeating the same snippet of code over and over again.
* Add `link` to `.PHONY` targets (I assumed you (the repo owner) or someone else just forgot to do it).