### PR TITLE
Fix gifs

### DIFF
--- a/stpv
+++ b/stpv
@@ -274,7 +274,7 @@ image_prepare() {
         dark_opts=
     fi
     # shellcheck disable=SC2086
-    convert "$conv_file"                            \
+    convert "$conv_file[0]"                         \
             -auto-orient                            \
             -resize ${width}x${height}              \
             $dark_opts                              \


### PR DESCRIPTION
`[0]` allows to display gifs by taking their first frame. It doesn't seem to affect plain images.