### PR TITLE
Fix error when there are no files matching the glob

### DIFF
--- a/stpvimg
+++ b/stpvimg
@@ -56,7 +56,7 @@ listen() {
     iskitty && return 0
 
     # cleanup any dead listeners if any
-    for f in /tmp/stpvimgfifo*-pid; do
+    for f in $(find /tmp/ -maxdepth 1 -name 'stpvimgfifo*-pid'); do
         pid=$(cat "$f")
         ppid=$(ps -h -p "$pid" -o ppid | xargs)
         if [ "$ppid" = 1 ]; then


### PR DESCRIPTION
I was working on other PRs and had this error:

```
cat: '/tmp/stpvimgfifo*-pid': No such file or directory
error: unsupported SysV option

Usage:
 ps [options]

 Try 'ps --help <simple|list|output|threads|misc|all>'
  or 'ps --help <s|l|o|t|m|a>'
 for additional help text.

For more details see ps(1).
```

It turned out that a glob simply outputs itself if nothing matches. So this PR replaces a plain globbing with find command that outputs nothing in that case.