### PR TITLE
Print location symlink pointing to

### DIFF
--- a/stpv
+++ b/stpv
@@ -393,7 +393,7 @@ add handle_link
 handle_link() {
     [ -L "$file_path" ] && {
         printf '\033[1m\033[36mSymbolic link to\033[0m ->\n'
-        printf '\033[1m\033[34m%s\033[0m\n' "$file_path"
+        printf '\033[1m\033[34m%s\033[0m\n' "$(readlink "$file_path")"
         echo
     }
 


### PR DESCRIPTION
Right now the text shows the symlink file location, which seems useless. 