### PR TITLE
ueberzugpp on Wayland support

### DIFF
--- a/stpvimg
+++ b/stpvimg
@@ -34,11 +34,6 @@ exists() {
     command -v "$1" >/dev/null
 }
 
-iswayland() {
-    [ -n "$WAYLAND_DISPLAY" ] ||
-        [ "$XDG_SESSION_TYPE" = 'wayland' ]
-}
-
 iskitty() {
     [ -n "$KITTY_PID" ]
 }
@@ -87,7 +82,7 @@ base_end()     { true;  }
 # ==== interface ueberzug ====
 
 ueberzug_usable() {
-    exists ueberzug && ! iswayland && [ -n "$DISPLAY" ]
+    exists ueberzug && [ -n "$DISPLAY" ] || [ -n "$WAYLAND_DISPLAY" ]
 }
 
 ueberzug_isalive() {


### PR DESCRIPTION
So there's a drop in replacement for ueberzug called  [ueberzugpp](https://github.com/jstkdng/ueberzugpp)  that support Wayland & there's a check in  stpv that disable ueberzug on Wayland, so I modified the check that now stpv use ueberzug on Wayland